### PR TITLE
Change chartkick.js source uri to working one

### DIFF
--- a/examples/demo/charts/charts.html
+++ b/examples/demo/charts/charts.html
@@ -12,7 +12,7 @@
         <script src="http://code.highcharts.com/highcharts.js"></script>
         -->
 
-        <script src="http://ankane.github.io/chartkick/chartkick.js"></script>
+        <script src="https://www.chartkick.com/chartkick.js"></script>
     </head>
     <body>
         {% line_chart exchange with min=0.4 id='rates' %}


### PR DESCRIPTION
I've replaced chartkick.js url in the demo file, previous url was redirecting to chartkick.com, hence demo wasn't working.