### PR TITLE
Fixed version comparsion

### DIFF
--- a/chartkick/ext.py
+++ b/chartkick/ext.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import json
 import itertools
 import functools
+from distutils.version import LooseVersiond
 
 import jinja2
 from jinja2 import nodes
@@ -68,7 +69,7 @@ class ChartExtension(Extension):
         options.update(name=name, id=id)
 
         # jinja2 prepends 'l_' or 'l_{{ n }}'(ver>=2.9) to keys
-        if jinja2.__version__ >= '2.9':
+        if LooseVersion(jinja2.__version__) >= LooseVersion('2.9'):
             kwargs = dict((k[4:], v) for (k, v) in kwargs.items())
         else:
             kwargs = dict((k[2:], v) for (k, v) in kwargs.items())


### PR DESCRIPTION
Comparsion of string for Jinja versions after 2.9 does not work because '2.10' < '2.9'
Fixed this by using distutils.version.LooseVersionid
